### PR TITLE
Providing a requeue wrapper around the elastigo bulk indexer

### DIFF
--- a/filter_file.go
+++ b/filter_file.go
@@ -3,9 +3,10 @@ package loges
 import (
 	//"bytes"
 	//"encoding/json"
-	u "github.com/araddon/gou"
 	"strings"
 	"time"
+
+	u "github.com/araddon/gou"
 )
 
 var expectedLevels = map[string]bool{
@@ -65,6 +66,7 @@ func FileFormatter(logstashType string, tags []string) LineTransform {
 						evt.Fields = make(map[string]interface{})
 						evt.Fields["host"] = hostName
 						evt.Fields["level"] = logLevel
+						evt.Fields["WriteErrs"] = d.WriteErrs
 						//evt.Fields = msg
 						//evt.Source = d.Source
 						//u.Debug(evt.String())
@@ -76,6 +78,7 @@ func FileFormatter(logstashType string, tags []string) LineTransform {
 						evt.Fields = make(map[string]interface{})
 						evt.Fields["host"] = hostName
 						evt.Fields["level"] = logLevel
+						evt.Fields["WriteErrs"] = d.WriteErrs
 						//evt.Fields = msg
 						//evt.Source = d.Source
 						//u.Debug(evt.String())
@@ -86,6 +89,7 @@ func FileFormatter(logstashType string, tags []string) LineTransform {
 				evt.Fields = make(map[string]interface{})
 				evt.Fields["host"] = hostName
 				evt.Fields["level"] = logLevel
+				evt.Fields["WriteErrs"] = d.WriteErrs
 				//evt.Fields = msg
 				//evt.Source = d.Source
 				//u.Debug(evt.String())

--- a/filter_fileflatten.go
+++ b/filter_fileflatten.go
@@ -2,10 +2,11 @@ package loges
 
 import (
 	"bytes"
-	"github.com/araddon/dateparse"
-	u "github.com/araddon/gou"
 	"io/ioutil"
 	"strings"
+
+	"github.com/araddon/dateparse"
+	u "github.com/araddon/gou"
 )
 
 // This formatter reads go files and performs:
@@ -112,7 +113,7 @@ func MakeFileFlattener(filename string, msgChan chan *LineEvent) func(string) {
 				// 	u.Warnf("ct=%d level:%s  \n\nline=%s", lineCt, string(data[pos+1:posEnd]), string(data))
 				// }
 				//u.Debugf("dt='%s'  data=%s", string(dataType), string(data[0:20]))
-				msgChan <- &LineEvent{Data: data, DataType: string(dataType), Source: filename}
+				msgChan <- &LineEvent{Data: data, DataType: string(dataType), Source: filename, WriteErrs: 0}
 			} else {
 				u.Error(err)
 			}

--- a/logstash.go
+++ b/logstash.go
@@ -5,9 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	u "github.com/araddon/gou"
 	"os"
 	"time"
+
+	u "github.com/araddon/gou"
 )
 
 var (
@@ -24,11 +25,12 @@ func init() {
 
 // Representing data about a line from FluentD
 type LineEvent struct {
-	Data     []byte
-	DataType string // DataType , probably should be called loglevel [METRIC, INFO,  DEBUG]
-	Source   string // Source = filename if file, else monit, etc
-	Offset   uint64
-	Item     interface{}
+	Data      []byte
+	DataType  string // DataType , probably should be called loglevel [METRIC, INFO,  DEBUG]
+	Source    string // Source = filename if file, else monit, etc
+	Offset    uint64
+	Item      interface{}
+	WriteErrs uint16
 }
 type LineTransform func(*LineEvent) *Event
 


### PR DESCRIPTION
Messages are being dropped from the bulk indexer queue if an error is
returned. This is the simplest fix I could come up with to requeue the
failed messages and record the number of attempts.

Also GoFmt changed some import lines..